### PR TITLE
Add quit channel to stop timer goroutine

### DIFF
--- a/internal/server/protocols.go
+++ b/internal/server/protocols.go
@@ -127,7 +127,7 @@ func (r *Room) end_protocol(h *Client) error {
 	defer r.Session.SessionMux.Unlock()
 	r.HikersMux.Lock()
 	defer r.HikersMux.Unlock()
-	r.Timer.UpdateTicker.Stop()
+	r.Timer.StopTicker()
 	r.Timer.CountdownTimer.Stop()
 	r.Timer.IsRunning = false
 	r.Timer.IsBreak = false

--- a/internal/server/timer_test.go
+++ b/internal/server/timer_test.go
@@ -1,0 +1,35 @@
+package server
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTickerStopTerminatesGoroutine(t *testing.T) {
+	timer := &Timer{FocusTime: 1, Pace: 1000}
+	h := &Client{Id: "1", Username: "test", MsgCh: make(chan ServerPacket, 1)}
+	room := &Room{
+		Id:      "room1",
+		Hikers:  map[string]*Client{"1": h},
+		Session: &Session{},
+		Timer:   timer,
+		Host:    "1",
+	}
+
+	timer.BeginFocusTime(room)
+	// allow goroutine to start
+	time.Sleep(10 * time.Millisecond)
+	timer.StopTicker()
+
+	done := make(chan struct{})
+	go func() {
+		timer.wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("update goroutine did not terminate")
+	}
+}


### PR DESCRIPTION
## Summary
- add `quit` channel and `wg` to `Timer`
- stop ticker loop with `StopTicker`
- close update loop in `end_protocol`
- test that ticker goroutine terminates

## Testing
- `go test ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6852f5dba904832485aeb8a17bf18409